### PR TITLE
Configurable polling, improved target-state logic, and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+*.tgz
+.dir-locals.el

--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ Update your config.json configuration file. See the example below.
 
 1. Change the IP in the example to the IP or hostname of your OpenGarage.
 1. Be sure to change the "YourPassword" part to the password used for your OpenGarage.
-1. Enjoy telling Siri to open and close your Garage as well as receiving push notifications on state change.
 1. Measure how long it takes for your garage door to close after triggering the state change using OpenGarage, including
    the warning beeps if applicable. Add a few seconds and set the value `openCloseDurationSecs` accordingly.
+1. Enjoy telling Siri to open and close your Garage as well as receiving push notifications on state change.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ made to work with OpenGarage
                 "accessory": "OpenGarage",
                 "name": "Garage",
                 "ip": "192.168.0.4",
-                "key": "YourPassword"
+                "key": "YourPassword",
+                "openCloseDurationSecs": 22,
+                "pollFrequencySecs": 60
             }
         ]
     }
@@ -31,3 +33,5 @@ made to work with OpenGarage
 1. Change the IP in the example to the IP or hostname of your OpenGarage.
 1. Be sure to change the "YourPassword" part to the password used for your OpenGarage.
 1. Enjoy telling Siri to open and close your Garage as well as receiving push notifications on state change.
+1. Measure how long it takes for your garage door to close after triggering the state change using OpenGarage, including
+   the warning beeps if applicable. Set the value `openCloseDurationSecs` accordingly.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,39 @@ made to work with OpenGarage
 
 ## Installation
 
-1. Install homebridge using: npm install -g homebridge
-1. Install this plugin using: npm install -g homebridge-og
-1. Update your config.json configuration file. See the example below.
+This plugin only works with OpenGarage Firmware 1.0.8 or later.
 
-## Example config.json
+You must have NodeJS `v8.1.4` or later installed as `homebridge-og` depends on JavaScript features introduced at that point. Check your node version:
+
+```
+node --version
+```
+
+You need [Homebridge](https://github.com/nfarina/homebridge) installed and configured. This plugin was developed against Homebridge `0.4.43`.
+
+```
+npm install -g homebridge
+```
+
+Install this plugin from source:
+
+```
+git clone ...
+cd homebridge-og
+npm pack
+sudo npm install -g homebridge-og-3.0.0.tgz
+```
+
+## Configuration
+
+Update your config.json configuration file. See the example below.
+
+- `ip` - The host name or IP address of your OpenGarage device
+- `key` - The password to control your OpenGarage device
+- `openCloseDurationSecs` - The amount of time within which an open/close transition should reliably complete (and OpenGarage will sense the new door state), including the OpenGarage warning beeps.
+- `pollFrequencySecs` - How often to poll OpenGarage for state changes. This will enable state updates for the garage door when not controlled via this homebridge plugin.
+
+### Sample config.json
 
 ```json
     {
@@ -34,4 +62,4 @@ made to work with OpenGarage
 1. Be sure to change the "YourPassword" part to the password used for your OpenGarage.
 1. Enjoy telling Siri to open and close your Garage as well as receiving push notifications on state change.
 1. Measure how long it takes for your garage door to close after triggering the state change using OpenGarage, including
-   the warning beeps if applicable. Set the value `openCloseDurationSecs` accordingly.
+   the warning beeps if applicable. Add a few seconds and set the value `openCloseDurationSecs` accordingly.

--- a/index.js
+++ b/index.js
@@ -1,92 +1,23 @@
-var request = require( "request" );
-var Service;
-var Characteristic;
+const OpenGarageModule = require("./lib/open_garage.js")
+const OpenGarageApiModule = require("./lib/open_garage_api.js")
 
 module.exports = function( homebridge ) {
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
+    let Service = homebridge.hap.Service
+    let Characteristic = homebridge.hap.Characteristic
 
+    class OpenGarageConnect {
+        constructor(log, config) {
+            let OpenGarageApi = OpenGarageApiModule(log)
+            let openGarageApi = new OpenGarageApi({
+                ip: config.ip,
+                key: config.key
+            })
+            let OpenGarage = OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date})
+            this.openGarage = new OpenGarage(config.name, true)
+        }
+        getServices() {
+            return([this.openGarage.garageService])
+        }
+    }
     homebridge.registerAccessory( "homebridge-og", "OpenGarage", OpenGarageConnect );
 };
-
-class OpenGarageConnect {
-    constructor( log, config ) {
-        this.log = log;
-
-        this.name = config.name;
-        this.ip = config.ip;
-        this.key = config.key;
-
-        this.garageService = new Service.GarageDoorOpener( this.name );
-
-        this.garageService
-            .getCharacteristic( Characteristic.CurrentDoorState )
-            .on( "get", this.getState.bind( this ) );
-
-        this.garageService
-            .getCharacteristic( Characteristic.TargetDoorState )
-            .on( "get", this.getState.bind( this ) )
-            .on( "set", this.changeState.bind( this ) );
-
-        this.garageService
-		        .getCharacteristic( Characteristic.ObstructionDetected )
-		        .on( "get", this.getStateObstruction.bind( this ) );
-    }
-
-    getStateObstruction ( callback ) {
-        callback( null, false );
-    };
-
-    getState ( callback ) {
-        this.log( "Getting current state..." );
-
-        request.get( { url: "http://" + this.ip + "/jc" }, function( err, response, body ) {
-            if ( !err && response.statusCode === 200 ) {
-                var value = JSON.parse( body ).door;
-
-                this.log( "Status garage: %s", value === 0 ? "closed" : "open" );
-                callback( null, value === 0 ? true : false );
-            } else {
-                this.log( "Error getting state: %s", err );
-                callback( err );
-            }
-        }.bind( this ) );
-    };
-
-    changeState ( state, callback ) {
-        this.log( "Set state to %s", state === Characteristic.TargetDoorState.CLOSED ? "closed" : "open" );
-
-        this.getState( function( err, actualState ) {
-            if ( !!state === actualState ) {
-
-                setTimeout( function() {
-                    this.garageService.setCharacteristic( Characteristic.CurrentDoorState, state );
-                    callback( null );
-                }.bind( this ), 10000 );
-            } else {
-
-                request.get( { url: "http://" + this.ip + "/cc?dkey=" + this.key + "&click=1" }, function( err, response, body ) {
-
-                    if ( !err && response.statusCode === 200 ) {
-                        this.log( "State change complete." );
-                        var currentState = ( state === Characteristic.TargetDoorState.CLOSED ) ?
-                            Characteristic.CurrentDoorState.CLOSED : Characteristic.CurrentDoorState.OPEN;
-
-                        /** Add delay to wait for the door to finish opening or closing */
-                        setTimeout( function() {
-                            this.garageService.setCharacteristic( Characteristic.CurrentDoorState, currentState );
-                            callback( null );
-                        }.bind( this ), 10000 );
-                    } else {
-                        this.log( "Error '%s' setting door state. Response: %s", err, body );
-                        callback( err || new Error( "Error setting door state." ) );
-                    }
-                }.bind( this ) );
-            }
-        }.bind( this ) );
-    };
-
-    getServices () {
-        return [ this.garageService ];
-    };
-}

--- a/index.js
+++ b/index.js
@@ -9,82 +9,84 @@ module.exports = function( homebridge ) {
     homebridge.registerAccessory( "homebridge-og", "OpenGarage", OpenGarageConnect );
 };
 
-function OpenGarageConnect( log, config ) {
-    this.log = log;
+class OpenGarageConnect {
+    constructor( log, config ) {
+        this.log = log;
 
-    this.name = config.name;
-    this.ip = config.ip;
-    this.key = config.key;
+        this.name = config.name;
+        this.ip = config.ip;
+        this.key = config.key;
 
-    this.garageService = new Service.GarageDoorOpener( this.name );
+        this.garageService = new Service.GarageDoorOpener( this.name );
 
-    this.garageService
-        .getCharacteristic( Characteristic.CurrentDoorState )
-        .on( "get", this.getState.bind( this ) );
+        this.garageService
+            .getCharacteristic( Characteristic.CurrentDoorState )
+            .on( "get", this.getState.bind( this ) );
 
-    this.garageService
-        .getCharacteristic( Characteristic.TargetDoorState )
-        .on( "get", this.getState.bind( this ) )
-        .on( "set", this.changeState.bind( this ) );
+        this.garageService
+            .getCharacteristic( Characteristic.TargetDoorState )
+            .on( "get", this.getState.bind( this ) )
+            .on( "set", this.changeState.bind( this ) );
 
-    this.garageService
-		.getCharacteristic( Characteristic.ObstructionDetected )
-		.on( "get", this.getStateObstruction.bind( this ) );
+        this.garageService
+		        .getCharacteristic( Characteristic.ObstructionDetected )
+		        .on( "get", this.getStateObstruction.bind( this ) );
+    }
+
+    getStateObstruction ( callback ) {
+        callback( null, false );
+    };
+
+    getState ( callback ) {
+        this.log( "Getting current state..." );
+
+        request.get( { url: "http://" + this.ip + "/jc" }, function( err, response, body ) {
+            if ( !err && response.statusCode === 200 ) {
+                var value = JSON.parse( body ).door;
+
+                this.log( "Status garage: %s", value === 0 ? "closed" : "open" );
+                callback( null, value === 0 ? true : false );
+            } else {
+                this.log( "Error getting state: %s", err );
+                callback( err );
+            }
+        }.bind( this ) );
+    };
+
+    changeState ( state, callback ) {
+        this.log( "Set state to %s", state === Characteristic.TargetDoorState.CLOSED ? "closed" : "open" );
+
+        this.getState( function( err, actualState ) {
+            if ( !!state === actualState ) {
+
+                setTimeout( function() {
+                    this.garageService.setCharacteristic( Characteristic.CurrentDoorState, state );
+                    callback( null );
+                }.bind( this ), 10000 );
+            } else {
+
+                request.get( { url: "http://" + this.ip + "/cc?dkey=" + this.key + "&click=1" }, function( err, response, body ) {
+
+                    if ( !err && response.statusCode === 200 ) {
+                        this.log( "State change complete." );
+                        var currentState = ( state === Characteristic.TargetDoorState.CLOSED ) ?
+                            Characteristic.CurrentDoorState.CLOSED : Characteristic.CurrentDoorState.OPEN;
+
+                        /** Add delay to wait for the door to finish opening or closing */
+                        setTimeout( function() {
+                            this.garageService.setCharacteristic( Characteristic.CurrentDoorState, currentState );
+                            callback( null );
+                        }.bind( this ), 10000 );
+                    } else {
+                        this.log( "Error '%s' setting door state. Response: %s", err, body );
+                        callback( err || new Error( "Error setting door state." ) );
+                    }
+                }.bind( this ) );
+            }
+        }.bind( this ) );
+    };
+
+    getServices () {
+        return [ this.garageService ];
+    };
 }
-
-OpenGarageConnect.prototype.getStateObstruction = function( callback ) {
-    callback( null, false );
-};
-
-OpenGarageConnect.prototype.getState = function( callback ) {
-    this.log( "Getting current state..." );
-
-    request.get( { url: "http://" + this.ip + "/jc" }, function( err, response, body ) {
-        if ( !err && response.statusCode === 200 ) {
-            var value = JSON.parse( body ).door;
-
-            this.log( "Status garage: %s", value === 0 ? "closed" : "open" );
-            callback( null, value === 0 ? true : false );
-        } else {
-            this.log( "Error getting state: %s", err );
-            callback( err );
-        }
-    }.bind( this ) );
-};
-
-OpenGarageConnect.prototype.changeState = function( state, callback ) {
-    this.log( "Set state to %s", state === Characteristic.TargetDoorState.CLOSED ? "closed" : "open" );
-
-    this.getState( function( err, actualState ) {
-        if ( !!state === actualState ) {
-
-            setTimeout( function() {
-                this.garageService.setCharacteristic( Characteristic.CurrentDoorState, state );
-                callback( null );
-            }.bind( this ), 10000 );
-        } else {
-
-            request.get( { url: "http://" + this.ip + "/cc?dkey=" + this.key + "&click=1" }, function( err, response, body ) {
-
-                if ( !err && response.statusCode === 200 ) {
-                    this.log( "State change complete." );
-                    var currentState = ( state === Characteristic.TargetDoorState.CLOSED ) ?
-                        Characteristic.CurrentDoorState.CLOSED : Characteristic.CurrentDoorState.OPEN;
-
-                    /** Add delay to wait for the door to finish opening or closing */
-                    setTimeout( function() {
-                        this.garageService.setCharacteristic( Characteristic.CurrentDoorState, currentState );
-                        callback( null );
-                    }.bind( this ), 10000 );
-                } else {
-                    this.log( "Error '%s' setting door state. Response: %s", err, body );
-                    callback( err || new Error( "Error setting door state." ) );
-                }
-            }.bind( this ) );
-        }
-    }.bind( this ) );
-};
-
-OpenGarageConnect.prototype.getServices = function() {
-    return [ this.garageService ];
-};

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -14,58 +14,57 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                 next(null, fn())
             }
             catch (error) {
-                log("error ", error)
-                next(error)
+                next(new Error(error))
             }
         }
     }
 
     class OpenGarage {
-        constructor(name, isClosed) {
+        constructor(name) {
             this.name = name
             this.currentState = {error: "Successful poll not yet completed"}
 
-            // TODO - this logic should be encapsulated in a state machine
-            this.lastTarget = {ts: 0, closed: isClosed}
+            this.lastTarget = undefined
 
-            this.garageService = new Service.GarageDoorOpener( this.name );
+            this.garageService = new Service.GarageDoorOpener( this.name )
 
             this.garageService
                 .getCharacteristic( Characteristic.CurrentDoorState )
-                .on( "get", this.getState.bind( this ) );
+                .on( "get", syncGetter(this.getState.bind( this ) ) )
 
             this.garageService
                 .getCharacteristic( Characteristic.TargetDoorState )
                 .on( "get", syncGetter(this.targetDoorState.bind( this ) ))
-                .on( "set", this.changeState.bind( this ) );
+                .on( "set", this.changeState.bind( this ) )
 
             this.garageService
 		            .getCharacteristic( Characteristic.ObstructionDetected )
-		            .on( "get", this.getStateObstruction.bind( this ) );
+		            .on( "get", syncGetter(this.getStateObstruction.bind( this ) ) )
             this.pollStateRefreshLoop()
         }
 
-        getStateObstruction ( callback ) {
-            callback( null, false );
-        };
+        getStateObstruction() {
+            return false
+        }
 
-        getState ( callback ) {
-            callback(null, this.currentDoorState())
-            log( "Getting current state..." );
-            this.triggerStateRefresh().then((isClosed) => {
-                log( "Status garage: %s", isClosed ? "closed" : "open" );
-            })
+        getState() {
+            log( "Getting current state asynchronously..." )
+            this.triggerStateRefresh().then(
+                (isClosed) => log( "Status garage: %s", isClosed ? "closed" : "open" ),
+                (err) => log ( "Error getting state: %s", err)
+            )
+            return this.currentDoorState()
         }
 
         isClosed() {
             if (this.currentState.success)
                 return this.currentState.success.door === 0
             else
-                throw this.currentState.error
+                throw new Error("Last poll failed - " + this.currentState.error)
         }
 
         targetDoorState () {
-            if ((Date.now() - this.lastTarget.ts) >= openDurationMs) { // past time expected to open
+            if (!this.lastTarget || ((Date.now() - this.lastTarget.ts) >= openDurationMs)) { // past time expected to open
                 if (this.isClosed())
                     return Characteristic.TargetDoorState.CLOSED
                 else
@@ -91,14 +90,13 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                 (state) => {
                     this.currentState = {success: state}
                     this.notify()
-                    log.debug( "Poll status garage: %s", this.isClosed() ? "closed" : "open" );
+                    log.debug( "Poll status garage: %s", this.isClosed() ? "closed" : "open" )
                     return this.isClosed
                 },
                 (error) => {
                     this.currentState = {error: error}
                     throw (error)
                 }
-
             )
         }
 
@@ -119,9 +117,9 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                 .updateValue(this.targetDoorState())
         }
 
-        changeState ( state, callback ) {
+        changeState( state, callback ) {
             let targetStateClosed = state === Characteristic.TargetDoorState.CLOSED
-            log( "Set state to %s", targetStateClosed ? "closed" : "open" );
+            log( "Set state to %s", targetStateClosed ? "closed" : "open" )
 
             openGarageApi.setTargetState(targetStateClosed)
                 .then(

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -23,8 +23,9 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
     class OpenGarage {
         constructor(name, isClosed) {
             this.name = name
-            // TODO - we should probably default to undefined, and return an error if we haven't heard from the state.
-            this.isClosed = isClosed
+            this.currentState = {error: "Successful poll not yet completed"}
+
+            // TODO - this logic should be encapsulated in a state machine
             this.lastTarget = {ts: 0, closed: isClosed}
 
             this.garageService = new Service.GarageDoorOpener( this.name );
@@ -41,7 +42,6 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
             this.garageService
 		            .getCharacteristic( Characteristic.ObstructionDetected )
 		            .on( "get", this.getStateObstruction.bind( this ) );
-            this.notify()
             this.pollStateRefreshLoop()
         }
 
@@ -57,9 +57,16 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
             })
         }
 
+        isClosed() {
+            if (this.currentState.success)
+                return this.currentState.success.door === 0
+            else
+                throw this.currentState.error
+        }
+
         targetDoorState () {
             if ((Date.now() - this.lastTarget.ts) >= openDurationMs) { // past time expected to open
-                if (this.isClosed)
+                if (this.isClosed())
                     return Characteristic.TargetDoorState.CLOSED
                 else
                     return Characteristic.TargetDoorState.OPEN
@@ -73,21 +80,27 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
 
         currentDoorState() {
             // If we haven't heard for the last couple of polls durations, we should return an error
-            if (this.isClosed)
+            if (this.isClosed())
                 return Characteristic.CurrentDoorState.CLOSED
             else
                 return Characteristic.CurrentDoorState.OPEN
         }
 
         triggerStateRefresh() {
-            return openGarageApi.getState().then((state) => {
-                this.isClosed = state.door === 0
-                this.notify()
-                log.debug( "Poll status garage: %s", this.isClosed ? "closed" : "open" );
-                return this.isClosed
-            })
-        }
+            return openGarageApi.getState().then(
+                (state) => {
+                    this.currentState = {success: state}
+                    this.notify()
+                    log.debug( "Poll status garage: %s", this.isClosed() ? "closed" : "open" );
+                    return this.isClosed
+                },
+                (error) => {
+                    this.currentState = {error: error}
+                    throw (error)
+                }
 
+            )
+        }
 
         pollStateRefreshLoop() {
             // reset poll timer if already set

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -1,0 +1,141 @@
+const request = require("request-promise-native")
+
+function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date}) {
+    let openDurationMs = config.openDurationMs || OpenGarageModule.defaults.openDurationMs
+    let pollFrequencyMs = config.pollFrequencyMs || OpenGarageModule.defaults.pollFrequencyMs
+    function after(ms, result) {
+        return new Promise((success, reject) => {
+            setTimeout(() => success(result), ms)
+        })
+    }
+    function syncGetter(fn) {
+        return (next) => {
+            try {
+                next(null, fn())
+            }
+            catch (error) {
+                log("error ", error)
+                next(error)
+            }
+        }
+    }
+
+    class OpenGarage {
+        constructor(name, isClosed) {
+            this.name = name
+            // TODO - we should probably default to undefined, and return an error if we haven't heard from the state.
+            this.isClosed = isClosed
+            this.lastTarget = {ts: 0, closed: isClosed}
+
+            this.garageService = new Service.GarageDoorOpener( this.name );
+
+            this.garageService
+                .getCharacteristic( Characteristic.CurrentDoorState )
+                .on( "get", this.getState.bind( this ) );
+
+            this.garageService
+                .getCharacteristic( Characteristic.TargetDoorState )
+                .on( "get", syncGetter(this.targetDoorState.bind( this ) ))
+                .on( "set", this.changeState.bind( this ) );
+
+            this.garageService
+		            .getCharacteristic( Characteristic.ObstructionDetected )
+		            .on( "get", this.getStateObstruction.bind( this ) );
+            this.notify()
+            this.pollStateRefreshLoop()
+        }
+
+        getStateObstruction ( callback ) {
+            callback( null, false );
+        };
+
+        getState ( callback ) {
+            callback(null, this.currentDoorState())
+            log( "Getting current state..." );
+            this.triggerStateRefresh().then((isClosed) => {
+                log( "Status garage: %s", isClosed ? "closed" : "open" );
+            })
+        }
+
+        targetDoorState () {
+            if ((Date.now() - this.lastTarget.ts) >= openDurationMs) { // past time expected to open
+                if (this.isClosed)
+                    return Characteristic.TargetDoorState.CLOSED
+                else
+                    return Characteristic.TargetDoorState.OPEN
+            } else {
+                if (this.lastTarget.closed)
+                    return Characteristic.TargetDoorState.CLOSED
+                else
+                    return Characteristic.TargetDoorState.OPEN
+            }
+        }
+
+        currentDoorState() {
+            // If we haven't heard for the last couple of polls durations, we should return an error
+            if (this.isClosed)
+                return Characteristic.CurrentDoorState.CLOSED
+            else
+                return Characteristic.CurrentDoorState.OPEN
+        }
+
+        triggerStateRefresh() {
+            return openGarageApi.getState().then((state) => {
+                this.isClosed = state.door === 0
+                this.notify()
+                log.debug( "Poll status garage: %s", this.isClosed ? "closed" : "open" );
+                return this.isClosed
+            })
+        }
+
+
+        pollStateRefreshLoop() {
+            // reset poll timer if already set
+            if (this.pollTimer) clearTimeout(this.pollTimer)
+            this.pollTimer = setTimeout(() => this.pollStateRefreshLoop(), pollFrequencyMs)
+
+            this.triggerStateRefresh().catch((err) => {
+                log("Error polling state", err)
+            })
+        }
+
+        notify() {
+            this.garageService.getCharacteristic(Characteristic.CurrentDoorState)
+                .updateValue(this.currentDoorState())
+            this.garageService.getCharacteristic(Characteristic.TargetDoorState)
+                .updateValue(this.targetDoorState())
+        }
+
+        changeState ( state, callback ) {
+            let targetStateClosed = state === Characteristic.TargetDoorState.CLOSED
+            log( "Set state to %s", targetStateClosed ? "closed" : "open" );
+
+            openGarageApi.setTargetState(targetStateClosed)
+                .then(
+                    (_) => {
+                        log("Target state successfully received.")
+                        this.lastTarget = {
+                            ts: Date.now(),
+                            closed: targetStateClosed
+                        }
+                        callback(null)
+                        return(after(openDurationMs, true))
+                    },
+                    (err) => {
+                        callback(err)
+                        throw(err)
+                    })
+                .then((_) => this.triggerStateRefresh())
+                .catch((err) => {
+                    log("Error changing state", err)
+                })
+        }
+    }
+
+    return OpenGarage
+}
+OpenGarageModule.defaults = {
+    openDurationMs: 25000,
+    pollFrequencyMs: 60000
+}
+module.exports = OpenGarageModule

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -1,8 +1,8 @@
 const request = require("request-promise-native")
 
 function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date}) {
-    let openDurationMs = config.openDurationMs || OpenGarageModule.defaults.openDurationMs
-    let pollFrequencyMs = config.pollFrequencyMs || OpenGarageModule.defaults.pollFrequencyMs
+    let openCloseDurationMs = (config.openCloseDurationSecs || OpenGarageModule.defaults.openCloseDurationSecs) * 1000
+    let pollFrequencyMs = (config.pollFrequencySecs || OpenGarageModule.defaults.pollFrequencySecs) * 1000
     function after(ms, result) {
         return new Promise((success, reject) => {
             setTimeout(() => success(result), ms)
@@ -64,7 +64,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
         }
 
         targetDoorState () {
-            if (!this.lastTarget || ((Date.now() - this.lastTarget.ts) >= openDurationMs)) { // past time expected to open
+            if (!this.lastTarget || ((Date.now() - this.lastTarget.ts) >= openCloseDurationMs)) { // past time expected to open
                 if (this.isClosed())
                     return Characteristic.TargetDoorState.CLOSED
                 else
@@ -130,7 +130,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                             closed: targetStateClosed
                         }
                         callback(null)
-                        return(after(openDurationMs, true))
+                        return(after(openCloseDurationMs, true))
                     },
                     (err) => {
                         callback(err)
@@ -146,7 +146,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
     return OpenGarage
 }
 OpenGarageModule.defaults = {
-    openDurationMs: 25000,
-    pollFrequencyMs: 60000
+    openCloseDurationSecs: 25,
+    pollFrequencySecs: 60
 }
 module.exports = OpenGarageModule

--- a/lib/open_garage_api.js
+++ b/lib/open_garage_api.js
@@ -1,0 +1,55 @@
+const request = require("request-promise-native")
+
+function OpenGarageApiModule(log) {
+    class OpenGarageApi{
+        constructor({ip, key}) {
+            this.key = key
+            this.baseUrl = "http://" + ip
+        }
+
+        urlFor(path, params) {
+            let url = this.baseUrl + path + "?dkey=" + this.key
+            if (params)
+                url = url + "&" + params
+            return url
+        }
+
+
+        getState() {
+            return request.get({ url: this.urlFor("/jc") }).then(
+                (body) => JSON.parse(body),
+                (err) => {
+                    log("Error getting state:", err.message)
+                    throw err
+                })
+        }
+
+        _handleResponse(body) {
+            let responseCode = JSON.parse(body).result
+            switch(responseCode) {
+            case 1: return true
+            case 2: throw new Error("Not authorized")
+            case 3: throw new Error("Mismatch")
+            case 16: throw new Error("Data missing")
+            case 17: throw new Error("Out of range")
+            case 18: throw new Error("Data Format Error")
+            case 32: throw new Error("Page Not Found")
+            case 48: throw new Error("Not Permitted")
+            case 64: throw new Error("Upload Failed")
+            default:
+                throw new Error("Unrecognized response code: " + responseCode)
+            }
+        }
+
+        setTargetState(closed) {
+            let url = this.urlFor(
+                "/cc",
+                closed ? "close=1" : "open=1")
+            log(url)
+            return request.get({url}).then((body) => this._handleResponse(body))
+        }
+    }
+
+    return OpenGarageApi
+}
+module.exports = OpenGarageApiModule

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "homebridge-og",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -93,6 +93,26 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
+		"asn1": {
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+			"integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+		},
+		"assert-plus": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+			"integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+		},
+		"async": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+		},
+		"aws-sign2": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+			"integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -134,6 +154,45 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"bl": {
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+			"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+			"requires": {
+				"readable-stream": "1.0.34"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"boom": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+			"integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+			"requires": {
+				"hoek": "0.9.1"
+			}
+		},
 		"brace-expansion": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -158,6 +217,11 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
 			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
 			"dev": true
+		},
+		"caseless": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+			"integrity": "sha1-W8oogdQUN/VLJAfr40iIx7mtT30="
 		},
 		"chalk": {
 			"version": "2.3.0",
@@ -232,6 +296,14 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"combined-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+			"integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+			"requires": {
+				"delayed-stream": "0.0.5"
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -252,8 +324,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cross-spawn": {
 			"version": "5.1.0",
@@ -265,6 +336,19 @@
 				"shebang-command": "1.2.0",
 				"which": "1.3.0"
 			}
+		},
+		"cryptiles": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+			"integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+			"requires": {
+				"boom": "0.4.2"
+			}
+		},
+		"ctype": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+			"integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
 		},
 		"debug": {
 			"version": "3.1.0",
@@ -295,6 +379,11 @@
 				"pinkie-promise": "2.0.1",
 				"rimraf": "2.6.2"
 			}
+		},
+		"delayed-stream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+			"integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
 		},
 		"doctrine": {
 			"version": "2.0.0",
@@ -474,6 +563,21 @@
 				"write": "0.2.1"
 			}
 		},
+		"forever-agent": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+			"integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+		},
+		"form-data": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+			"integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+			"requires": {
+				"async": "0.9.2",
+				"combined-stream": "0.0.7",
+				"mime": "1.2.11"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -541,6 +645,32 @@
 			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 			"dev": true
 		},
+		"hawk": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+			"integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+			"requires": {
+				"boom": "0.4.2",
+				"cryptiles": "0.2.2",
+				"hoek": "0.9.1",
+				"sntp": "0.2.4"
+			}
+		},
+		"hoek": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+			"integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+		},
+		"http-signature": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+			"integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+			"requires": {
+				"asn1": "0.1.11",
+				"assert-plus": "0.1.5",
+				"ctype": "0.5.3"
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -572,8 +702,7 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
 			"version": "3.3.0",
@@ -691,6 +820,11 @@
 				"jsonify": "0.0.0"
 			}
 		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -722,6 +856,16 @@
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
 			}
+		},
+		"mime": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+			"integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+		},
+		"mime-types": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+			"integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
 		},
 		"mimic-fn": {
 			"version": "1.1.0",
@@ -770,6 +914,16 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node-uuid": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+			"integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+		},
+		"oauth-sign": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+			"integrity": "sha1-12f1FpMlYg6rLgh+8MRy53PbZGE="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -878,6 +1032,21 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
+		"psl": {
+			"version": "1.1.28",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
+			"integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+			"integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+		},
 		"readable-stream": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -891,6 +1060,29 @@
 				"safe-buffer": "5.1.1",
 				"string_decoder": "1.0.3",
 				"util-deprecate": "1.0.2"
+			}
+		},
+		"request": {
+			"version": "2.49.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.49.0.tgz",
+			"integrity": "sha1-DU9jSNwzSAWbVT5Ntg/SR43mYqc=",
+			"requires": {
+				"aws-sign2": "0.5.0",
+				"bl": "0.9.5",
+				"caseless": "0.8.0",
+				"combined-stream": "0.0.7",
+				"forever-agent": "0.5.2",
+				"form-data": "0.1.4",
+				"hawk": "1.1.1",
+				"http-signature": "0.10.1",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "1.0.2",
+				"node-uuid": "1.4.8",
+				"oauth-sign": "0.5.0",
+				"qs": "2.3.3",
+				"stringstream": "0.0.6",
+				"tough-cookie": "2.4.2",
+				"tunnel-agent": "0.4.3"
 			}
 		},
 		"require-uncached": {
@@ -994,6 +1186,14 @@
 				"is-fullwidth-code-point": "2.0.0"
 			}
 		},
+		"sntp": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+			"integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+			"requires": {
+				"hoek": "0.9.1"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1018,6 +1218,11 @@
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
+		},
+		"stringstream": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -1083,11 +1288,25 @@
 				"os-tmpdir": "1.0.2"
 			}
 		},
+		"tough-cookie": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
+			"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
+			"requires": {
+				"psl": "1.1.28",
+				"punycode": "1.4.1"
+			}
+		},
 		"tryit": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
 			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
 			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
 		},
 		"type-check": {
 			"version": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,8 +151,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bl": {
 			"version": "0.9.5",
@@ -197,11 +196,15 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"caller-path": {
 			"version": "0.1.0",
@@ -304,11 +307,15 @@
 				"delayed-stream": "0.0.5"
 			}
 		},
+		"commander": {
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.0",
@@ -354,7 +361,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -385,6 +391,11 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
 			"integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
 		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		},
 		"doctrine": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
@@ -398,8 +409,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
 			"version": "4.9.0",
@@ -581,8 +591,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
@@ -594,7 +603,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -630,6 +638,11 @@
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
 		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -655,6 +668,11 @@
 				"hoek": "0.9.1",
 				"sntp": "0.2.4"
 			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
 		"hoek": {
 			"version": "0.9.1",
@@ -693,7 +711,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -844,8 +861,7 @@
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-			"dev": true
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
 		},
 		"lru-cache": {
 			"version": "4.1.1",
@@ -877,7 +893,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -885,23 +900,53 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"requires": {
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"supports-color": "5.4.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
 			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -935,7 +980,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -972,8 +1016,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -1083,6 +1126,24 @@
 				"stringstream": "0.0.6",
 				"tough-cookie": "2.4.2",
 				"tunnel-agent": "0.4.3"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.4.2"
 			}
 		},
 		"require-uncached": {
@@ -1199,6 +1260,11 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -1347,8 +1413,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 	},
 	"directories": {},
 	"engines": {
-		"homebridge": ">=0.2.0",
-		"node": ">=0.12.0"
+		"homebridge": ">=0.4.0",
+		"node": ">=8.1.4"
 	},
 	"keywords": [
 		"homebridge-plugin",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
 	},
 	"bundleDependencies": false,
 	"dependencies": {
-		"request": "2.49.x"
+		"mocha": "^5.2.0",
+		"request": "2.49.x",
+		"request-promise-native": "^1.0.5"
 	},
 	"deprecated": false,
 	"description": "Homebridge garage plugin for OpenGarage",
@@ -37,5 +39,5 @@
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
-	"version": "2.1.0"
+	"version": "3.0.0"
 }

--- a/test/open_garage_test.js
+++ b/test/open_garage_test.js
@@ -1,0 +1,232 @@
+const assert = require('assert');
+const OpenGarageModule = require("../lib/open_garage.js")
+
+class MockDevice {
+  constructor(name) {
+    this.name = name
+    this.characteristics = {}
+  }
+  getCharacteristic(characteristic) {
+    if (!(characteristic.name in this.characteristics))
+      this.characteristics[characteristic.name] = new Characteristic(characteristic)
+    return this.characteristics[characteristic.name]
+  }
+  setCharacteristic(characteristic, value) {
+    this.characteristics[characteristic.name] = value
+    return this
+  }
+}
+
+class Characteristic {
+    constructor(char) {
+        this.name = char.name
+        this.characteristic = char
+        this._on = {}
+    }
+
+    on(key, fn) {
+        this._on[key] = fn
+        return this;
+    }
+
+    triggerGetSync() {
+        var result
+        this._on['get']((err, r) => result =r )
+        return result
+    }
+
+    triggetSetAsync(value) {
+        return new Promise((accept, reject) => {
+            this._on['set'](value, (err) => {
+                if (err != null)
+                    reject(err)
+                else
+                    accept()
+            })
+        })
+    }
+
+    updateValue(value) {
+        this.value = value
+    }
+}
+
+class GarageDoorOpener extends MockDevice {}
+const MockHomebridge = {
+    hap: {
+        uuid: { generate: (input) => input },
+        Service: {GarageDoorOpener},
+        Characteristic: {
+            Manufacturer: {name: "Manufacturer"},
+            Model: {name: "Model"},
+            SerialNumber: {name: "SerialNumber"},
+            TargetDoorState: {name: "TargetDoorState", CLOSED: "T_CLOSED", OPEN: "T_OPEN"},
+            CurrentDoorState: {name: "CurrentDoorState", CLOSED: "CLOSED", OPEN: "OPEN"},
+            ObstructionDetected: {name: "ObstructionDetected"}
+        }
+    }
+}
+
+function MockLog() {
+    this.console.log.apply(null, arguments)
+}
+MockLog.debug = console.log
+
+function eventually(fn) {
+    let deadline = Date.now() + 1000
+    return new Promise((success, reject) => {
+        let timer = setInterval(() => {
+            try {
+                success(fn())
+                clearInterval(timer)
+            }
+            catch(err) {
+                if (Date.now() > deadline) {
+                    clearInterval(timer)
+                    reject(err)
+                }
+            }
+        }, 50)
+    })
+}
+
+describe('OpenGarage', function() {
+    var openGarage
+    var mockOpenGarageApi
+    var MockSetTimeout
+    var MockClearTimeout
+    var MockDate
+    var currentDoorState
+    var targetDoorState
+    let pollFrequencyMs = OpenGarageModule.defaults.pollFrequencyMs
+    var openDurationMs = OpenGarageModule.defaults.openDurationMs
+    let Characteristic = MockHomebridge.hap.Characteristic
+    let Service = MockHomebridge.hap.Service
+
+    class MockOpenGarageApi {
+        constructor() {
+            this.isClosed = false
+        }
+        getState() {
+            return Promise.resolve({door: this.isClosed ? 0 : 1})
+        }
+
+        setTargetState(closed) {
+            this.targetClosedState = closed
+            return Promise.resolve(true)
+        }
+    }
+
+    beforeEach(() => {
+        let timers = []
+        let timerIdx = 0
+        MockSetTimeout = function(fn, duration) {
+            timerIdx += 1
+            let timer = {idx: timerIdx, fn, duration}
+            timers.push(timer)
+            return timer
+        }
+        MockClearTimeout = function({idx}) {
+            arrayIdx = timers.findIndex((timer) => timer.idx == idx)
+            if (arrayIdx != -1)
+                timers.splice(arrayIdx, 1)
+        }
+        MockSetTimeout.getTimers = () => timers
+        MockSetTimeout.invoke = ({idx}) => {
+            let timer = timers.find((timer) => timer.idx == idx)
+            MockClearTimeout(timer)
+            timer.fn()
+        }
+        MockSetTimeout.clear = () => { timers = [] }
+        MockDate = {
+            currentTime: 1529629810000,
+            now: () => MockDate.currentTime
+        }
+        mockOpenGarageApi = new MockOpenGarageApi
+        let OpenGarage = OpenGarageModule(MockLog, {}, {
+            openGarageApi: mockOpenGarageApi,
+            Service: Service,
+            Characteristic: Characteristic,
+            setTimeout: MockSetTimeout,
+            clearTimeout: MockClearTimeout,
+            Date: MockDate})
+        mockOpenGarageApi.isClosed = true
+        openGarage = new OpenGarage("garage", true)
+        currentDoorState = openGarage.garageService.getCharacteristic(Characteristic.CurrentDoorState)
+        targetDoorState = openGarage.garageService.getCharacteristic(Characteristic.TargetDoorState)
+    })
+
+    describe('#constructor', () => {
+        it('polls the status and propagates values to Home', async () => {
+            assert.equal(openGarage.isClosed, true)
+            assert.equal(Characteristic.CurrentDoorState.CLOSED, currentDoorState.value)
+            assert.equal(Characteristic.TargetDoorState.CLOSED, targetDoorState.value)
+
+            pollTimer = openGarage.pollTimer
+            mockOpenGarageApi.isClosed = false
+
+            MockSetTimeout.invoke(pollTimer)
+
+            // new timer should be scheduled
+            assert.notEqual(pollTimer, openGarage.pollTimer)
+
+            // when api call returns these should be updated
+            await eventually(() => {
+                assert.equal(openGarage.isClosed, false)
+                assert.equal(Characteristic.CurrentDoorState.OPEN, currentDoorState.value)
+                assert.equal(Characteristic.TargetDoorState.OPEN, targetDoorState.value)
+            })
+        })
+
+        it('sends the command to close the garage door', async () => {
+            await targetDoorState.triggetSetAsync(Characteristic.TargetDoorState.OPEN)
+
+            assert.equal(mockOpenGarageApi.targetClosedState, false)
+            assert.equal(openGarage.currentDoorState(), Characteristic.CurrentDoorState.CLOSED)
+            assert.equal(openGarage.targetDoorState(), Characteristic.TargetDoorState.OPEN)
+            
+            let [pollTimer, afterTimer] = MockSetTimeout.getTimers()
+            assert.equal(pollTimer.duration, pollFrequencyMs) // default poll
+            assert.equal(afterTimer.duration, openDurationMs) // poll
+
+            mockOpenGarageApi.isClosed = false
+            MockDate.currentTime += openDurationMs
+            MockSetTimeout.invoke(afterTimer)
+
+            await eventually(() =>{
+                assert.equal(mockOpenGarageApi.targetClosedState, false)
+                assert.equal(openGarage.currentDoorState(), Characteristic.CurrentDoorState.OPEN)
+                assert.equal(openGarage.targetDoorState(), Characteristic.TargetDoorState.OPEN)
+            })
+            // the existing poll is cancelled and a new poll is scheduled
+            await eventually(() => {
+                let [currentTimer] = MockSetTimeout.getTimers()
+                assert.equal(currentTimer.duration, pollFrequencyMs)
+                assert.notEqual(pollTimer.idx, currentTimer.idx)
+            })
+        })
+
+        it('reverts the target door state if the state does not change after openDurationMs', async () => {
+            await targetDoorState.triggetSetAsync(Characteristic.TargetDoorState.OPEN)
+
+            assert.equal(mockOpenGarageApi.targetClosedState, false)
+            assert.equal(openGarage.currentDoorState(), Characteristic.CurrentDoorState.CLOSED)
+            assert.equal(openGarage.targetDoorState(), Characteristic.TargetDoorState.OPEN)
+            
+            let [pollTimer, afterTimer] = MockSetTimeout.getTimers()
+            assert.equal(pollTimer.duration, pollFrequencyMs) // default poll
+            assert.equal(afterTimer.duration, openDurationMs) // poll
+
+            MockSetTimeout.invoke(afterTimer)
+
+            await eventually(() =>{
+                assert.equal(mockOpenGarageApi.targetClosedState, false)
+                assert.equal(openGarage.currentDoorState(), Characteristic.CurrentDoorState.CLOSED)
+                assert.equal(openGarage.targetDoorState(), Characteristic.TargetDoorState.OPEN)
+            })
+            MockDate.currentTime += openDurationMs
+            assert.equal(openGarage.targetDoorState(), Characteristic.TargetDoorState.CLOSED)
+        })
+    })
+
+});


### PR DESCRIPTION
This is a monster pull request. I've been running my fork for the past week and it has worked much better. Notable changes:

- Target state is more intelligent as we now use OpenGarage firmware 1.0.8's support for setting target state. This fixes issue https://github.com/OpenGarage/homebridge-og/issues/4
- Initial state is properly reported when HomeBridge restart and Home is already open on an iOS device. Fixes issue #5.
- Configurable polling now introduced. Previously, garage state was only queried when the home app was opened. Now, the state is polled and pushed to Home so that notifications can happen.
- Improved target state transition logic. I introduced a configurable time window in which the garage door state change that was initiated should be reliably observed by sensor. If it fails to reach this state, it rolls back to the previous target (target = current). This improves how the state change looks in the app.
- Unit tests! Helpful as it is difficult to justify opening and closing your garage door over and over just so you can teat the code.

