### PR TITLE
Add Vehicle Presence Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ module.exports = function( homebridge ) {
             this.openGarage = new OpenGarage(config.name, true)
         }
         getServices() {
-            return([this.openGarage.garageService])
+            return([
+		   this.openGarage.garageService,
+		   this.openGarage.vehicleService,
+	           ])
         }
     }
     homebridge.registerAccessory( "homebridge-og", "OpenGarage", OpenGarageConnect );

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -40,11 +40,22 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
             this.garageService
                 .getCharacteristic( Characteristic.ObstructionDetected )
                 .on( "get", syncGetter(this.getStateObstruction.bind( this ) ) )
+
+            this.vehicleService = new Service.OccupancySensor( "Vehicle Present" )
+
+            this.vehicleService.getCharacteristic( Characteristic.OccupancyDetected )
+                .on( "get", syncGetter(this.getVehicleOccupancy.bind ( this ) ) )
+
             this.pollStateRefreshLoop()
         }
 
         getStateObstruction() {
             return false
+        }
+
+        getVehicleOccupancy() {
+            log( "Status vehicle: %s", this.currentVehicleState() ? "present" : "not present" )
+            return this.currentVehicleState()
         }
 
         getState() {
@@ -59,6 +70,13 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
         isClosed() {
             if (this.currentState.success)
                 return this.currentState.success.door === 0
+            else
+                throw new Error("Last poll failed - " + this.currentState.error)
+        }
+
+        isVehiclePresent() {
+            if (this.currentState.success)
+                return this.currentState.success.vehicle === 1
             else
                 throw new Error("Last poll failed - " + this.currentState.error)
         }
@@ -83,6 +101,14 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                 return Characteristic.CurrentDoorState.CLOSED
             else
                 return Characteristic.CurrentDoorState.OPEN
+        }
+
+        currentVehicleState() {
+            // If we haven't heard for the last couple of polls durations, we should return an error
+            if (this.isVehiclePresent())
+                return Characteristic.OccupancyDetected.OCCUPANCY_DETECTED
+            else
+                return Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED
         }
 
         triggerStateRefresh() {
@@ -115,6 +141,8 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                 .updateValue(this.currentDoorState())
             this.garageService.getCharacteristic(Characteristic.TargetDoorState)
                 .updateValue(this.targetDoorState())
+            this.vehicleService.getCharacteristic(Characteristic.OccupancyDetected)
+                .updateValue(this.currentVehicleState())
         }
 
         changeState( state, callback ) {

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -38,8 +38,8 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                 .on( "set", this.changeState.bind( this ) )
 
             this.garageService
-		            .getCharacteristic( Characteristic.ObstructionDetected )
-		            .on( "get", syncGetter(this.getStateObstruction.bind( this ) ) )
+                .getCharacteristic( Characteristic.ObstructionDetected )
+                .on( "get", syncGetter(this.getStateObstruction.bind( this ) ) )
             this.pollStateRefreshLoop()
         }
 
@@ -91,7 +91,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
                     this.currentState = {success: state}
                     this.notify()
                     log.debug( "Poll status garage: %s", this.isClosed() ? "closed" : "open" )
-                    return this.isClosed
+                    return this.isClosed()
                 },
                 (error) => {
                     this.currentState = {error: error}


### PR DESCRIPTION
Just got my OpenGarage a week ago, and I love how flexible the unit is.  Found this plugin, and have been enjoying using it, so I took a stab at implementing vehicle presence.  I've been using this feature for a few days and it's been working well.

* Address Issue  #8
* Add occupancy sensor service to OpenGarage class.
* Only shows vehicle occupancy when garage door is closed.  Appears unoccupied when door is up.
---
![IMG_6658D807E4BB-1](https://user-images.githubusercontent.com/948796/89980568-02617c80-dc27-11ea-8577-ea22f5f1802c.jpeg)
![IMG_91DF1B47B4E8-1](https://user-images.githubusercontent.com/948796/89980675-3b015600-dc27-11ea-8cdd-4342388cc23d.jpeg)
<img width="681" alt="Screen Shot 2020-08-11 at 10 51 20 PM" src="https://user-images.githubusercontent.com/948796/89980742-59ffe800-dc27-11ea-91fa-e4625fc28ea0.png">

