### PR TITLE
Update homebridge-og for Homebridge v2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"directories": {},
 	"engines": {
-		"homebridge": ">=0.4.0",
+		"homebridge": "^1.6.0 || ^2.0.0-beta.0",
 		"node": ">=8.1.4"
 	},
 	"keywords": [


### PR DESCRIPTION
This change updates the `engines.homebridge` value in `package.json` to `^1.6.0 || ^2.0.0-beta.0` to indicate compatibility with Homebridge v2.

No other code changes were necessary as the plugin does not use any of the deprecated APIs.