### PR TITLE
Improve timeout handling

### DIFF
--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -1,4 +1,4 @@
-const request = require("request-promise-native")
+// request-promise-native was previously required here but never used
 
 function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date}) {
     let openCloseDurationMs = (config.openCloseDurationSecs || OpenGarageModule.defaults.openCloseDurationSecs) * 1000

--- a/lib/open_garage_api.js
+++ b/lib/open_garage_api.js
@@ -1,10 +1,26 @@
 const request = require("request-promise-native")
+const http = require("http")
 
 function OpenGarageApiModule(log) {
     class OpenGarageApi{
         constructor({ip, key}) {
             this.key = key
             this.baseUrl = "http://" + ip
+            this.agent = new http.Agent({ keepAlive: false })
+        }
+
+        _request(options, retries = 1) {
+            options.agent = this.agent
+            options.timeout = 5000
+            return request.get(options).catch(err => {
+                if (retries > 0 && err.cause) {
+                    if (err.cause.code === 'ECONNRESET' || err.cause.code === 'ETIMEDOUT') {
+                        log(`Transient ${err.cause.code} error, retrying request`)
+                        return this._request(options, retries - 1)
+                    }
+                }
+                throw err
+            })
         }
 
         urlFor(path, params) {
@@ -16,7 +32,7 @@ function OpenGarageApiModule(log) {
 
 
         getState() {
-            return request.get({ url: this.urlFor("/jc") }).then(
+            return this._request({ url: this.urlFor("/jc") }).then(
                 (body) => JSON.parse(body),
                 (err) => {
                     log("Error getting state:", err.message)
@@ -46,7 +62,7 @@ function OpenGarageApiModule(log) {
                 "/cc",
                 closed ? "close=1" : "open=1")
             log(url)
-            return request.get({url}).then((body) => this._handleResponse(body))
+            return this._request({url}).then((body) => this._handleResponse(body))
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
 	],
 	"name": "homebridge-og",
 	"optionalDependencies": {},
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
+        "scripts": {
+                "test": "mocha"
+        },
 	"version": "3.1.1"
 }

--- a/test/open_garage_test.js
+++ b/test/open_garage_test.js
@@ -98,8 +98,8 @@ describe('OpenGarage', function() {
     var MockDate
     var currentDoorState
     var targetDoorState
-    let pollFrequencyMs = OpenGarageModule.defaults.pollFrequencyMs
-    var openDurationMs = OpenGarageModule.defaults.openDurationMs
+    let pollFrequencyMs = OpenGarageModule.defaults.pollFrequencySecs * 1000
+    var openDurationMs = OpenGarageModule.defaults.openCloseDurationSecs * 1000
     let Characteristic = MockHomebridge.hap.Characteristic
     let Service = MockHomebridge.hap.Service
 


### PR DESCRIPTION
## Summary
- retry transient ETIMEDOUT errors in `OpenGarageApi`
- remove unused dependency in `open_garage.js`
- fix default references in tests
- run mocha via `npm test`

## Testing
- `npm test` *(fails: Service.OccupancySensor is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_684380276384832cb099697ad6529ff7