### PR TITLE
Add GitHub Actions workflow to auto-publish to npm on release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,7 @@ name: npm publish
 on:
   release:
     types: [published]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,41 @@
+name: npm publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - name: Validate version is unpublished
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "homebridge-og@$VERSION" version >/dev/null 2>&1; then
+            echo "Version $VERSION is already published. Bump package.json version first."
+            exit 1
+          fi
+          echo "Publishing homebridge-og@$VERSION"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically publishes to npm when a GitHub Release is published, or on demand via the Actions tab. Tests run first — publish is blocked if they fail.

---

## One-time setup required

### Step 1 — Create an npm Automation token

1. Log in to **npmjs.com**
2. Go to **Account → Access Tokens → Generate New Token**
3. Choose **Granular Access Token**
4. Set the following:
   - **Package**: `homebridge-og` → permission: **Read and write**
   - **Bypass 2FA**: enabled (required for CI automation)
5. Copy the token — you won't see it again

### Step 2 — Add the token as a GitHub secret

1. Go to **github.com/OpenGarage/homebridge-og → Settings → Secrets and variables → Actions**
2. Click **New repository secret**
   - **Name**: `NPM_TOKEN`
   - **Value**: the token from Step 1
3. Click **Add secret**

That's it. The workflow will now have publish access.

---

## How to publish a new version

1. Bump `version` in `package.json`, update `CHANGELOG.md`, commit and push
2. Go to **GitHub → Releases → Draft a new release**
3. Create a new tag matching the version (e.g. `v3.2.1`)
4. Add release notes, click **Publish release**
5. The workflow triggers automatically → tests run → publishes to npm

Alternatively, trigger it manually any time from **Actions → npm publish → Run workflow**.

## Test plan
- [ ] `NPM_TOKEN` secret added (Steps 1–2 above)
- [ ] Publish a release → workflow runs, tests pass, package appears on npm
- [ ] Re-running on an already-published version fails with a clear error message
- [ ] Manual trigger via Actions tab works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)